### PR TITLE
Add dynamic width adjustment and footer removal for Petsmont

### DIFF
--- a/src/BensonScreenShotFixes.ts
+++ b/src/BensonScreenShotFixes.ts
@@ -4,18 +4,19 @@ export default class BensonScreenshotFixes extends Common {
   public init(containerId: string, debugMode: boolean): void {
     const func = () => {
       this.DaisyLondonRemoveWidthFromSlickTrack();
+      this.run(this.PetsmonRemoveDuplicateFooters());
     };
     this.exec({ containerId, debugMode, func });
   }
 
   private run(
-    callback: Function,
+    callback: void,
     options: {
       onError?: (error: Error) => void;
     } = {}
   ) {
     try {
-      callback();
+      callback;
     } catch (error) {
       options.onError?.(error as Error);
     }
@@ -23,19 +24,30 @@ export default class BensonScreenshotFixes extends Common {
 
   //Daisy London
   private DaisyLondonRemoveWidthFromSlickTrack() {
-    setTimeout(() => {
-      this.dom.querySelectorAll(".slick-list.draggable").forEach((parent) => {
-        const track = parent.querySelector(".slick-track") as HTMLElement;
-        if (track) {
-          track.style.width = "";
-          const currentSlide = track.querySelector(
-            ".slick-slide.slick-current"
-          ) as HTMLElement;
-          if (currentSlide) {
-            currentSlide.style.width = "100%";
+    try {
+      setTimeout(() => {
+        this.dom.querySelectorAll(".slick-list.draggable").forEach((parent) => {
+          const track = parent.querySelector(".slick-track") as HTMLElement;
+          if (track) {
+            track.style.width = "";
+            const currentSlide = track.querySelector(
+              ".slick-slide.slick-current"
+            ) as HTMLElement;
+            if (currentSlide) {
+              currentSlide.style.width = "100%";
+            }
           }
-        }
-      });
-    }, 2000);
+        });
+      }, 2000);
+    } catch (error) {}
+  }
+
+  private PetsmonRemoveDuplicateFooters() {
+    const footers = this.dom.querySelectorAll("#shopify-section-cwr-footer");
+    footers.forEach((footer, index) => {
+      if (index > 0) {
+        footer.remove();
+      }
+    });
   }
 }

--- a/src/Screenshot.ts
+++ b/src/Screenshot.ts
@@ -1509,6 +1509,19 @@ class ScreenshotFixes extends Common {
     }
   };
 
+  // Petsmont
+  private setWidthForSlickTracks = () => {
+    setInterval(() => {
+      const slickTracks = this.dom.querySelectorAll('.slick-track');
+      slickTracks.forEach((track: HTMLElement) => {
+         const actualWidth = track.getAttribute('actualWidth');
+         if (actualWidth) {
+             track.style.setProperty('width', actualWidth, 'important');
+         }
+      });
+    }, 1000);
+  };
+
   //Springinger
   private hideShopifyMinicartElements() {
     const elements = this.dom.querySelectorAll(
@@ -1560,6 +1573,7 @@ class ScreenshotFixes extends Common {
       { ids: [2792], functions: [this.removeEmptyCartClass] },
       { ids: [2994], functions: [this.adjustHeaderPadding] },
       { ids: [174], functions: [this.setImagesVisible] },
+      { ids: [2841], functions: [this.setWidthForSlickTracks] }, 
 
       // { ids: [2925], functions: [this.setPositionForAnnouncementBarSMEL] },
     ];


### PR DESCRIPTION
Introduce functions to dynamically adjust the width of slick tracks and remove duplicate footers for the Petsmont section. Update initialization to include these new functionalities.

Ticket: https://heatmap-dot-com.atlassian.net/browse/IMF-694?atlOrigin=eyJpIjoiMTgxMDQwZTBlYTRkNDQzMDhmMTgyMzExYTg0NDhhOWQiLCJwIjoiaiJ9