### PR TITLE
Add functionality to remove height from product card details

### DIFF
--- a/src/Screenshot.ts
+++ b/src/Screenshot.ts
@@ -1489,38 +1489,54 @@ class ScreenshotFixes extends Common {
 
   private adjustHeaderPadding = () => {
     if (this.insideIframe) {
-        const header = this.dom.querySelector(
-            '#shopify-section-header.shopify-section.header-section'
-        ) as HTMLElement;
-        if (header) {
-            header.style.setProperty('padding-bottom', '0px', 'important');
-        }
+      const header = this.dom.querySelector(
+        "#shopify-section-header.shopify-section.header-section"
+      ) as HTMLElement;
+      if (header) {
+        header.style.setProperty("padding-bottom", "0px", "important");
+      }
     }
   };
 
   private setImagesVisible = () => {
     if (this.insideIframe) {
-        const images = this.dom.querySelectorAll('img');
-        if (!images.length) return;
- 
-        images.forEach(img => {
-            (img as HTMLElement).style.setProperty('visibility', 'visible', 'important');
-        });
+      const images = this.dom.querySelectorAll("img");
+      if (!images.length) return;
+
+      images.forEach((img) => {
+        (img as HTMLElement).style.setProperty(
+          "visibility",
+          "visible",
+          "important"
+        );
+      });
     }
   };
 
   // Petsmont
   private setWidthForSlickTracks = () => {
     setInterval(() => {
-      const slickTracks = this.dom.querySelectorAll('.slick-track');
-      slickTracks.forEach((track: HTMLElement) => {
-         const actualWidth = track.getAttribute('actualWidth');
-         if (actualWidth) {
-             track.style.setProperty('width', actualWidth, 'important');
-         }
-      });
+      try {
+        const slickTracks = this.dom.querySelectorAll(".slick-track");
+        slickTracks.forEach((track: HTMLElement) => {
+          const actualWidth = track.getAttribute("actualWidth");
+          if (actualWidth) {
+            track.style.setProperty("width", actualWidth, "important");
+          }
+        });
+      } catch (error) {}
     }, 1000);
   };
+
+  //Remi
+  private removeHeightFromProductCardDetails = () => {
+    try{
+
+      this.dom
+      .querySelectorAll<HTMLElement>(".product-card__info .v-stack")
+      .forEach(element => element.style.height = '0');
+    } catch (error) {}
+  }
 
   //Springinger
   private hideShopifyMinicartElements() {
@@ -1573,7 +1589,8 @@ class ScreenshotFixes extends Common {
       { ids: [2792], functions: [this.removeEmptyCartClass] },
       { ids: [2994], functions: [this.adjustHeaderPadding] },
       { ids: [174], functions: [this.setImagesVisible] },
-      { ids: [2841], functions: [this.setWidthForSlickTracks] }, 
+      { ids: [2841], functions: [this.setWidthForSlickTracks] },
+      { ids: [2948], functions: [this.removeHeightFromProductCardDetails] },
 
       // { ids: [2925], functions: [this.setPositionForAnnouncementBarSMEL] },
     ];


### PR DESCRIPTION
Introduce a method to eliminate excess height in product card details, addressing layout issues on Remi. 

Ticket: https://heatmap-dot-com.atlassian.net/browse/IMF-506