### PR TITLE
Change AerifyShowNowButtonDisplay to use setInterval for better display handling

### DIFF
--- a/src/Screenshot.ts
+++ b/src/Screenshot.ts
@@ -1836,12 +1836,12 @@ class ScreenshotFixes extends Common {
 
   // Aerial: 2538
   private AerifyShowNowButtonDisplay = () => {
-    setTimeout(() => {
+    setInterval(() => {
       try {
         this.dom.querySelector<HTMLElement>('#custom_sticky_atc')
           .style.removeProperty("display");
       } catch (error) {}
-    }, 2000)
+    }, 1000)
   }
 
   private functionsMap: Record<number, (() => void)[]> =


### PR DESCRIPTION
Replace setTimeout with setInterval in AerifyShowNowButtonDisplay for improved display management. Adjusted interval timing for more responsive updates.